### PR TITLE
Fix "close" button for undesired anchor to the top

### DIFF
--- a/tutorial/layouts/partials/nav.html
+++ b/tutorial/layouts/partials/nav.html
@@ -1,4 +1,4 @@
-<a id="close" href="#">×</a>
+<a id="close" href="#close">×</a>
 <ol>
     <li>
         <a href="#introduction">Introduction</a>


### PR DESCRIPTION
Clicking the close button of side menu should not change position of the scroll bar.

- `<a id="close" href="#">×</a>`: Clicking this would trigger a `#` anchor, which leads the scroll bar to the top. It is very annoying when user is just wanting to close the side menu.
- `<a id="close" href="#close">×</a>`: Clicking this would trigger a `#close` anchor, which is not very elegant for there is not any real anchor point of it, but it works fine than how it did before.